### PR TITLE
Bugfix/console printing broke

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,13 +117,13 @@ StyleLinter.prototype.build = function() {
      if(results.errored){
        if(_this.onError)
          _this.onError(results.results[0]);
+       if(!_this.disableConsoleLogging )
+         console.log(results.output);
        if(_this.testFailingFiles){
          return _this.testGenerator(relativePath, results.results[0]);
        } else {
          return '';
        }
-       if(!_this.disableConsoleLogging )
-         console.log(results.output);
      } else {
        if(_this.testPassingFiles){
          return _this.testGenerator(relativePath);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ StyleLinter.prototype.availableOptions = ['onError',
                                           'testPassingFiles' ,
                                           'testGenerator',
                                           'linterConfig',
-                                          'disableConsoleLogging'];
+                                          'disableConsoleLogging',
+                                          'console'];
 
 /**
  * Creates a new StyleLinter instance.
@@ -26,6 +27,7 @@ StyleLinter.prototype.availableOptions = ['onError',
  * - testFailingFiles       (Generate tests for failing files)
  * - testPassingFiles       (Generate tests for passing files)
  * - disableConsoleLogging  (Disables error logging in console)
+ * - console  (Custom console)
  * @class
  */
 function StyleLinter(inputNodes, options) {
@@ -118,7 +120,7 @@ StyleLinter.prototype.build = function() {
        if(_this.onError)
          _this.onError(results.results[0]);
        if(!_this.disableConsoleLogging )
-         console.log(results.output);
+         _this.console.log(results.output);
        if(_this.testFailingFiles){
          return _this.testGenerator(relativePath, results.results[0]);
        } else {

--- a/index.js
+++ b/index.js
@@ -37,10 +37,8 @@ function StyleLinter(inputNodes, options) {
 
   for(var i = 0; i < this.availableOptions.length; i++){
     var option = this.availableOptions[i];
-    if( option === 'testGenerator'){
-      if(!options[option]){
-        continue;
-      }
+    if(typeof options[option] === "undefined" || options[option] === null){
+      continue;
     }
     this[option] = options[option];
     delete options[option];

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ StyleLinter.prototype.availableOptions = ['onError',
                                           'testPassingFiles' ,
                                           'testGenerator',
                                           'linterConfig',
-                                          'disableConsoleLogging',
+                                          'log',
                                           'console'];
 
 /**
@@ -26,8 +26,8 @@ StyleLinter.prototype.availableOptions = ['onError',
  * - generateTests          (Generate tests for all files)
  * - testFailingFiles       (Generate tests for failing files)
  * - testPassingFiles       (Generate tests for passing files)
- * - disableConsoleLogging  (Disables error logging in console)
- * - console  (Custom console)
+ * - log                    (Disables error logging in console)
+ * - console                (Custom console)
  * @class
  */
 function StyleLinter(inputNodes, options) {
@@ -35,6 +35,12 @@ function StyleLinter(inputNodes, options) {
 
   if(!options.linterConfig){
     options.linterConfig = {};
+  }
+
+  this.log = true;
+  if(typeof options['disableConsoleLogging'] !== "undefined"){
+    console.warn('"disableConsoleLogging" propety has been deprecated in favour of "log"');
+    this.log = !options['disableConsoleLogging'];
   }
 
   for(var i = 0; i < this.availableOptions.length; i++){
@@ -119,7 +125,7 @@ StyleLinter.prototype.build = function() {
      if(results.errored){
        if(_this.onError)
          _this.onError(results.results[0]);
-       if(!_this.disableConsoleLogging )
+       if(_this.log )
          _this.console.log(results.output);
        if(_this.testFailingFiles){
          return _this.testGenerator(relativePath, results.results[0]);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "broccoli": "^0.16.9",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "chai-spies": "^0.7.1",
     "mocha": "^2.4.5",
     "stylelint-selector-bem-pattern": "^1.0.0",
     "walk-sync": "^0.2.6"

--- a/tests/test.js
+++ b/tests/test.js
@@ -37,14 +37,14 @@ describe('Broccoli StyleLint Plugin', function() {
     it('ignores file specified config');
 
     it('stylelint plugins work', function(){
-      var opt = {disableConsoleLogging:true, linterConfig:{syntax:'sass', configFile:'tests/fixtures/.bemTestStylelintrc'}};
+      var opt = {log:false, linterConfig:{syntax:'sass', configFile:'tests/fixtures/.bemTestStylelintrc'}};
       return buildAndLint('tests/fixtures/test-plugin', opt).then(function(results){
         assert.equal(lintErrors[0].warnings.length,1);
       });
     });
 
     it('returns usefull source name onError', function(){
-      var opt = {disableConsoleLogging:true, linterConfig:{syntax:'sass', configFile:'tests/fixtures/.bemTestStylelintrc'}};
+      var opt = {log:false, linterConfig:{syntax:'sass', configFile:'tests/fixtures/.bemTestStylelintrc'}};
       return buildAndLint('tests/fixtures/test-plugin', opt).then(function(results){
         assert.equal(lintErrors[0].source,'has-error.scss');
       });
@@ -106,28 +106,28 @@ describe('Broccoli StyleLint Plugin', function() {
       var loggingTestConfig;
 
       beforeEach(function() {
-        loggingTestConfig  = {disableConsoleLogging:false,
+        loggingTestConfig  = {log:true,
                                console: console,
                                linterConfig:{syntax:'sass', configFile:'tests/fixtures/.bemTestStylelintrc'}};
       });
 
 
-      it('should log when disableConsoleLogging=false', function(){
+      it('should log when log=true', function(){
         chai.spy.on(console, 'log');
         return buildAndLint('tests/fixtures/test-plugin', loggingTestConfig).then(function(results){
           expect(console.log).to.have.been.called();
         });
       })
 
-      it('should not log when disableConsoleLogging=true', function(){
+      it('should not log when log=false', function(){
         chai.spy.on(console, 'log');
-        loggingTestConfig.disableConsoleLogging = true
+        loggingTestConfig.log = false
         return buildAndLint('tests/fixtures/test-plugin', loggingTestConfig).then(function(results){
           expect(console.log).to.not.have.been.called();
         });
       })
     })
-    
+
     describe('StyleLint Configuration', function(){
 
       it('cant set files option', function(){
@@ -158,7 +158,7 @@ describe('Broccoli StyleLint Plugin', function() {
       }
 
       beforeEach(function() {
-        generateTestsConfig  = {disableConsoleLogging:true, linterConfig:{syntax:'sass', formatter: 'string'}};
+        generateTestsConfig  = {log:false, linterConfig:{syntax:'sass', formatter: 'string'}};
       });
 
       describe('Generate Tests', function(){
@@ -223,7 +223,7 @@ describe('Broccoli StyleLint Plugin', function() {
     var generateTestsConfig;
 
     beforeEach(function() {
-      generateTestsConfig  = {disableConsoleLogging:true, linterConfig:{syntax:'sass', formatter: 'string'}};
+      generateTestsConfig  = {log:false, linterConfig:{syntax:'sass', formatter: 'string'}};
     });
 
     it('correctly handles nested folders', function() {
@@ -278,7 +278,7 @@ function walkTestsOutputReadableTree(results){
 }
 
 function buildAndLint(sourcePath, options, onError) {
-  options = options || {disableConsoleLogging:true, linterConfig:{syntax:'sass', formatter: 'string'}};
+  options = options || {log:false, linterConfig:{syntax:'sass', formatter: 'string'}};
   options.onError = function(results) {
     lintErrors.push(results);
   };

--- a/tests/test.js
+++ b/tests/test.js
@@ -3,9 +3,12 @@ var StyleLinter =    require('..');
 var walkSync =       require('walk-sync');
 var broccoli =       require('broccoli');
 var chai =           require('chai');
+var spies =          require('chai-spies');
 var fs =             require('fs');
 
 chai.use(chaiAsPromised);
+chai.use(spies);
+
 var assert = chai.assert;
 var expect = chai.expect;
 var builder, lintErrors;
@@ -99,6 +102,32 @@ describe('Broccoli StyleLint Plugin', function() {
 
     });
 
+    describe('logging', function() {
+      var loggingTestConfig;
+
+      beforeEach(function() {
+        loggingTestConfig  = {disableConsoleLogging:false,
+                               console: console,
+                               linterConfig:{syntax:'sass', configFile:'tests/fixtures/.bemTestStylelintrc'}};
+      });
+
+
+      it('should log when disableConsoleLogging=false', function(){
+        chai.spy.on(console, 'log');
+        return buildAndLint('tests/fixtures/test-plugin', loggingTestConfig).then(function(results){
+          expect(console.log).to.have.been.called();
+        });
+      })
+
+      it('should not log when disableConsoleLogging=true', function(){
+        chai.spy.on(console, 'log');
+        loggingTestConfig.disableConsoleLogging = true
+        return buildAndLint('tests/fixtures/test-plugin', loggingTestConfig).then(function(results){
+          expect(console.log).to.not.have.been.called();
+        });
+      })
+    })
+    
     describe('StyleLint Configuration', function(){
 
       it('cant set files option', function(){
@@ -231,6 +260,7 @@ describe('Broccoli StyleLint Plugin', function() {
                    ).to.eventually.equal(passedTestAssertion);
     });
   });
+
 });
 
 function readTestFile(testPaths){


### PR DESCRIPTION
Few changes

- improved test code
- deprecates `disableConsoleLogging` in favour for `log`
- fixes broken console logging
- adds test so that it doesn't break again 