### PR TITLE
don't mutate options

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ function StyleLinter(inputNodes, options) {
     var name = option.name;
     var defaultValue = option.default || this[name];
     this[name] = typeof options[name] === "undefined" ?  defaultValue : options[name];
-    delete options[name];
   }
 
   //TODO:remove this deprecation on v1 release

--- a/tests/test.js
+++ b/tests/test.js
@@ -120,6 +120,14 @@ describe('Broccoli StyleLint Plugin', function() {
 
     describe('StyleLint Configuration', function(){
 
+      it("doesn't mutate options", function() {
+        function generateTest() { return 'OK!'; }
+        var options = {disableTestGeneration:true, testGenerator: generateTest};
+        new StyleLinter('', options);
+        assert.equal(options.testGenerator, generateTest, 'options.testGenerator is intact');
+        assert.equal(options.disableTestGeneration, true, 'options.disableTestGeneration is intact');
+      });
+
       it('cant set files option', function(){
         var options = {linterConfig:{files:['a','b']}};
         var tree = new StyleLinter('', options);


### PR DESCRIPTION
If the same options hash is passed to multiple `StyleLinter` instances, the first one would previously delete all the options, leaving only the defaults for any subsequent instances.

Resolves billybonks/ember-cli-stylelint#46