### PR TITLE
Don't destroy options

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ function StyleLinter(inputNodes, options) {
     var name = option.name;
     var defaultValue = option.default || this[name];
     this[name] = typeof options[name] === "undefined" ?  defaultValue : options[name];
-    delete options[name];
   }
 
   //TODO:remove this deprecation on v1 release


### PR DESCRIPTION
Currently we destroy the options object, when it is passed it and this doesn't play well with the linter being called multiple times with the same object.

i guess the only problem here is `broccoli-persistant-filter` gets called with all of stylelint options, instead of the left overs.

in theory we should maybe create an option object just for `broccoli-persistant-filter`.