### PR TITLE
Fix version of stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "ignore": "^3.3.6",
     "js-string-escape": "~1.0.1",
     "merge": "~1.2.0",
-    "stylelint": "^v8.2.0"
+    "stylelint": "^8.0.0"
   }
 }


### PR DESCRIPTION
There should not be a `v` in the version, and we should set to `^8.0.0` so anything over 8 satisfies the dep.