### PR TITLE
 Use `co.wrap()` instead of Promise-chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "broccoli": "^0.16.9",
     "chai": "^4.1.2",
-    "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "co": "^4.6.0",
     "eslint": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
+    "co": "^4.6.0",
     "eslint": "^4.17.0",
     "mocha": "^5.0.0",
     "stylelint-selector-bem-pattern": "^2.0.0",

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var co = require('co');
-var chaiAsPromised = require('chai-as-promised');
 var StyleLinter =    require('..');
 var walkSync =       require('walk-sync');
 var broccoli =       require('broccoli');
@@ -10,7 +9,6 @@ var spies =          require('chai-spies');
 var merge =          require('merge');
 var fs =             require('fs');
 
-chai.use(chaiAsPromised);
 chai.use(spies);
 
 var expect = chai.expect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,12 +306,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai-as-promised@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
-  dependencies:
-    check-error "^1.0.2"
-
 chai-spies@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/chai-spies/-/chai-spies-1.0.0.tgz#d16b39336fb316d03abf8c375feb23c0c8bb163d"
@@ -365,7 +359,7 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-check-error@^1.0.1, check-error@^1.0.2:
+check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 


### PR DESCRIPTION
This is used by `ember-cli` internally for tests too, because it enables us to use something that looks roughly like async/await without sacrificing compatibility with Node 4 and 6.

/cc @billybonks 