### PR TITLE
package.json: Override `stylelint-selector-bem-pattern/stylelint` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "js-string-escape": "~1.0.1",
     "merge": "~1.2.0",
     "stylelint": "~8.4.0"
+  },
+  "resolutions": {
+    "stylelint-selector-bem-pattern/stylelint": "~8.4.0"
   }
 }


### PR DESCRIPTION
Otherwise this would cause `stylelint-selector-bem-pattern` to rely on `stylelint@9` which is incompatible with Node 4

This should hopefully fix the currently broken CI builds for Node 4

see also: https://yarnpkg.com/lang/en/docs/selective-version-resolutions/

/cc @billybonks 