### PR TITLE
[ENHANCEMENT] Allow multiple language support for test generation

### DIFF
--- a/tests/__snapshots__/test.js.snap
+++ b/tests/__snapshots__/test.js.snap
@@ -53,3 +53,34 @@ QUnit.test('no-errors0.scss should pass stylelint', function(assert) {
 
 "
 `;
+
+exports[`Broccoli StyleLint Plugin Generated Tests when using multiple languages generates happy path tests for each language 1`] = `
+"QUnit.module('Stylelint');
+
+QUnit.test('style.css should pass stylelint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'style.css should pass stylelint');
+});
+
+QUnit.test('style.less should pass stylelint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'style.less should pass stylelint');
+});
+
+QUnit.test('style.sass should pass stylelint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'style.sass should pass stylelint');
+});
+
+QUnit.test('style.scss should pass stylelint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'style.scss should pass stylelint');
+});
+
+QUnit.test('style.sss should pass stylelint', function(assert) {
+  assert.expect(1);
+  assert.ok(true, 'style.sss should pass stylelint');
+});
+
+"
+`;

--- a/tests/fixtures/multi-language/happy-path/style.css
+++ b/tests/fixtures/multi-language/happy-path/style.css
@@ -1,0 +1,10 @@
+#should-be-allowed-by-sass-lint-test-config-yml {
+  color: green;
+}
+
+nav {
+  margin: 20em auto 0;
+  width: 786em;
+  height: 45em;
+  border-radius: 10em;
+}

--- a/tests/fixtures/multi-language/happy-path/style.less
+++ b/tests/fixtures/multi-language/happy-path/style.less
@@ -1,0 +1,12 @@
+@border-radius: 2em;
+
+#should-be-allowed-by-sass-lint-test-config-yml {
+  color: green;
+}
+
+nav {
+  margin: 20em auto 0;
+  width: 788em;
+  height: 45em;
+  border-radius: @border-radius;
+}

--- a/tests/fixtures/multi-language/happy-path/style.sass
+++ b/tests/fixtures/multi-language/happy-path/style.sass
@@ -1,0 +1,8 @@
+@mixin border-radius: ($values)
+  border-radius: $values
+
+nav
+  margin: 20em auto 0
+  width: 786em
+  height: 45em
+  @include border-radius(10em)

--- a/tests/fixtures/multi-language/happy-path/style.scss
+++ b/tests/fixtures/multi-language/happy-path/style.scss
@@ -1,0 +1,26 @@
+#should-be-allowed-by-sass-lint-test-config-yml {
+  color: green;
+}
+
+.dry-border-for-sass {
+  border {
+    left: {
+      width: 4em;
+      color: #333333;
+    }
+    right: {
+      width: 2em;
+      color: black;
+    }
+  }
+}
+
+@mixin border-radius ($values) {
+  border-radius: $values;
+}
+nav {
+  margin: 20em auto 0;
+  width: 786em;
+  height: 45em;
+  @include border-radius(10em);
+}

--- a/tests/fixtures/multi-language/happy-path/style.sss
+++ b/tests/fixtures/multi-language/happy-path/style.sss
@@ -1,0 +1,11 @@
+a
+  color: blue
+
+.multiline,
+.selector
+  box-shadow: 1em 0 9em rgba(0, 0, 0, .4),
+              1em 0 3em rgba(0, 0, 0, .6)
+
+@media (max-width: 4em)
+  .body
+    padding: 0 0

--- a/tests/test.js
+++ b/tests/test.js
@@ -81,11 +81,6 @@ describe('Broccoli StyleLint Plugin', function() {
         assertExtensions(extension, extension, [extension]);
       });
 
-      it('defaults to scss',function(){
-        var extension = 'scss';
-        assertExtensions(null, extension, [extension]);
-      });
-
     });
 
     describe('logging', function() {
@@ -180,28 +175,36 @@ describe('Broccoli StyleLint Plugin', function() {
 
       describe('Property testPassingFiles', function(){
        it('doesnt generate tests for failing files', function(){
-         return buildAndAssertFile({testPassingFiles: true}, 'nested-dir/has-errors2.stylelint-test.js', true);
+         return buildAndAssertFile({testPassingFiles: true}, 'nested-dir/has-errors2.scss.stylelint-test.js', true);
        });
 
        it('generates tests for passing files', function(){
-         return buildAndAssertFile({testPassingFiles: true}, 'nested-dir/no-errors.stylelint-test.js', false);
+         return buildAndAssertFile({testPassingFiles: true}, 'nested-dir/no-errors.scss.stylelint-test.js', false);
        });
       });
 
       describe('Property testFailingFiles', function(){
        it('doesnt generate tests for passing files', function(){
-         return buildAndAssertFile({testFailingFiles: true}, 'nested-dir/has-errors2.stylelint-test.js', false);
+         return buildAndAssertFile({testFailingFiles: true}, 'nested-dir/has-errors2.scss.stylelint-test.js', false);
        });
 
        it('generates tests for failing files', function(){
-         return buildAndAssertFile({testFailingFiles: true}, 'nested-dir/no-errors.stylelint-test.js', true);
+         return buildAndAssertFile({testFailingFiles: true}, 'nested-dir/no-errors.scss.stylelint-test.js', true);
        });
       });
     });
   });
 
   describe('Generated Tests', function(){
-
+    describe('when using multiple languages', function(){
+      it('generates happy path tests for each language',  co.wrap(function *(){
+        let results = yield buildAndLint('tests/fixtures/multi-language/happy-path', {
+          linterConfig: { formatter: 'string' },
+          group:'app'
+        });
+        return expect(readTestFile(walkTestsOutputReadableTree(results))).toMatchSnapshot();
+      }));
+    });
     describe('when grouping is true', function() {
       it('correctly handles nested folders', co.wrap(function *() {
         let results = yield buildAndLint('tests/fixtures/grouped-test-generation', {testFailingFiles:true, group:'app'});
@@ -226,9 +229,9 @@ describe('Broccoli StyleLint Plugin', function() {
       it('correctly handles nested folders', co.wrap(function *() {
         let results = yield buildAndLint('tests/fixtures/test-generation', {testFailingFiles:true});
         return expect(walkTestsOutputTree(results)).toEqual([
-          'has-errors.stylelint-test.js',
-          'nested-dir/has-errors2.stylelint-test.js',
-          'nested-dir/no-errors.stylelint-test.js',
+          'has-errors.scss.stylelint-test.js',
+          'nested-dir/has-errors2.scss.stylelint-test.js',
+          'nested-dir/no-errors.scss.stylelint-test.js',
         ]);
       }));
 


### PR DESCRIPTION
### Summary
#### Before this change:
A user needed to pass in `syntax` in `linterConfig` to specify the kind of postCSS file to generate tests for. If `syntax` was not passed in, it was defaulted to `scss`.

#### After this change:
If `syntax` is not passed in, or an empty string is passed in for it, all supported postCSS formats (we support `['sss','scss','sass','css','less']`) will be considered for test generation. 

For the case of files with same names but different path like `style.css` and `style.less`, a different test will be generated for each one of them

Implementation change needed to enable this:
- default behaviour of `getDestFilePath` is slightly tweaked so that file extension is also included in the resulting `relativePath`. 
Example: `nested-dir/has-errors2.stylelint-test.js`-> `nested-dir/has-errors2.scss.stylelint-test.js`
This change should be alright since it is not really exposed to the end user.

### Follow-up
This PR only contains happy path test cases, will be creating error-path test cases shortly!
