### PR TITLE
Refactor/decouple options from this

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
       let resultTree = new BroccoliStyleLint(inputNode, options);
 
       const testGenerators   = require('aot-test-generators');
-      let testGenerator = testGenerators[resultTree.testingFramework];
+      let testGenerator = testGenerators[resultTree.internalOptions.testingFramework];
       let header = testGenerator.suiteHeader('Stylelint');
       let footer = testGenerator.suiteFooter();
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chalk": "~2.4.1",
     "ignore": "^5.0.2",
     "js-string-escape": "~1.0.1",
+    "lodash.defaultsdeep": "^4.6.0",
     "stylelint": "^9.5.0"
   },
   "jest": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -48,7 +48,7 @@ describe('Broccoli StyleLint Plugin', function() {
 
       it('uses string formatter by default', function(){
         builder = StyleLinter.create('', {});
-        expect(builder.linterConfig.formatter).toEqual('string');
+        expect(builder.internalOptions.linterConfig.formatter).toEqual('string');
       });
 
     });
@@ -107,7 +107,7 @@ describe('Broccoli StyleLint Plugin', function() {
         it('uses new geneator if testingFramework key is present', function() {
           var options = {testingFramework:'qunit'};
           let linter = StyleLinter.create('', options);
-          expect(linter.testGenerator).toEqual(require('../src/suite-generator'));
+          expect(linter.internalOptions.testGenerator).toEqual(require('../src/suite-generator'));
         });
       });
 
@@ -123,18 +123,16 @@ describe('Broccoli StyleLint Plugin', function() {
       it('cant set files option', function(){
         var options = {linterConfig:{files:['a','b']}};
         var tree = StyleLinter.create('', options);
-        expect(tree.linterConfig.files).toBe(null);
-
+        expect(tree.internalOptions.linterConfig.files).toBe(null);
       });
-
     });
 
     it('sets options on object', function(){
       var linterConfig = {files: null, formatter: 'string', syntax: 'scss'};
       var options = {linterConfig:linterConfig, testPassingFiles:true};
       var linter = StyleLinter.create('', options);
-      expect(linter.testPassingFiles).toBe(true);
-      expect(linter.linterConfig).toEqual(linterConfig);
+      expect(linter.internalOptions.testPassingFiles).toBe(true);
+      expect(linter.internalOptions.linterConfig).toEqual(linterConfig);
     });
 
     describe('Tests', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,6 +3774,11 @@ lodash.defaults@~2.3.0:
     lodash._objecttypes "~2.3.0"
     lodash.keys "~2.3.0"
 
+lodash.defaultsdeep@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz#bec1024f85b1bd96cbea405b23c14ad6443a6f81"
+  integrity sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=
+
 lodash.escape@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-2.3.0.tgz#844c38c58f844e1362ebe96726159b62cf5f2a58"


### PR DESCRIPTION
currently options are assinged to the this namespace, which makes it harder to work with, logic is more simplified if we assign it to a sub namespace