### PR TITLE
don't rebuild results if no results array

### DIFF
--- a/src/broccoli-stylelint.js
+++ b/src/broccoli-stylelint.js
@@ -184,6 +184,10 @@ class BroccoliStyleLint extends Filter {
     *  }
     */
   processResults(results, relativePath) {
+    if(results.results.length === 0){
+      results.source = relativePath;
+      return results;
+    }
     let resultsInner = results.results[0];
     resultsInner.errored = results.errored;
     resultsInner.source = relativePath;


### PR DESCRIPTION
if file is ignored then a different hash returns which causes plugin to break, the whole ignore flow does need a bit more work.